### PR TITLE
fix: support Python 3.11 by replacing PEP 695 type aliases with TypeAlias

### DIFF
--- a/matthewplotlib/colormaps.py
+++ b/matthewplotlib/colormaps.py
@@ -12,29 +12,30 @@ For example:
 ![](images/colormaps.png)
 """
 
-from typing import Callable
+from typing import Callable, Union
+from typing_extensions import TypeAlias
 from numpy.typing import ArrayLike
 
 import numpy as np
 
 
-# # # 
+# # #
 # COLORMAP TYPES
 
 
-type ContinuousColorMap = Callable[
+ContinuousColorMap: TypeAlias = Callable[
     [ArrayLike],
     np.ndarray,
 ] # float[...] -> uint8[..., 3]
 
 
-type DiscreteColorMap = Callable[
+DiscreteColorMap: TypeAlias = Callable[
     [ArrayLike],
     np.ndarray,
 ] # int[...] -> uint8[..., 3]
 
 
-type ColorMap = ContinuousColorMap | DiscreteColorMap
+ColorMap: TypeAlias = Union[ContinuousColorMap, DiscreteColorMap]
 
 
 # # # 

--- a/matthewplotlib/colors.py
+++ b/matthewplotlib/colors.py
@@ -1,24 +1,27 @@
 from __future__ import annotations
 
+from typing import Union
+from typing_extensions import TypeAlias
+
 import numpy as np
 
 from numpy.typing import NDArray
 
 
-# # # 
+# # #
 # COLOR TYPES
 
 
-type Color = NDArray # uint8[3]
+Color: TypeAlias = NDArray # uint8[3]
 
 
-type ColorLike = (
-    str
-    | NDArray # float[3] (0 to 1) or uint8[3] (0 to 255)
-    | tuple[int, int, int]
-    | tuple[float, float, float]
-    | Color
-)
+ColorLike: TypeAlias = Union[
+    str,
+    NDArray, # float[3] (0 to 1) or uint8[3] (0 to 255)
+    "tuple[int, int, int]",
+    "tuple[float, float, float]",
+    Color,
+]
 
 
 # # # 

--- a/matthewplotlib/data.py
+++ b/matthewplotlib/data.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import cast
+from typing import Union, cast
+from typing_extensions import TypeAlias
 
 import numpy as np
 import einops
@@ -10,38 +11,38 @@ from numpy.typing import NDArray, ArrayLike
 from matthewplotlib.colors import ColorLike, parse_color
 
 
-# # # 
+# # #
 # Types
 
 
-type number = int | float | np.integer | np.floating
+number: TypeAlias = Union[int, float, "np.integer", "np.floating"]
 
 
-type ColorSpec = (
-    None
-    | ColorLike
-    | ArrayLike # uint8[n, 3]
-)
+ColorSpec: TypeAlias = Union[
+    None,
+    ColorLike,
+    ArrayLike, # uint8[n, 3]
+]
 
 
-type Series = (
-    NDArray                                     # number[n,2]
-    | tuple[NDArray, ColorSpec]                 # number[n,2], colors
-    | tuple[ArrayLike, ArrayLike]               # number[n]^2
-    | tuple[ArrayLike, ArrayLike, ColorSpec]    # number[n]^2, colors
-    | axis                                      # axis
-    | tuple[axis, ColorSpec]                    # axis, colors
-)
+Series: TypeAlias = Union[
+    NDArray,                                     # number[n,2]
+    "tuple[NDArray, ColorSpec]",                 # number[n,2], colors
+    "tuple[ArrayLike, ArrayLike]",               # number[n]^2
+    "tuple[ArrayLike, ArrayLike, ColorSpec]",    # number[n]^2, colors
+    "axis",                                      # axis
+    "tuple[axis, ColorSpec]",                    # axis, colors
+]
 
 
-type Series3 = (
-    NDArray                                             # number[n,3]
-    | tuple[NDArray, ColorSpec]                         # number[n,3], colors
-    | tuple[ArrayLike, ArrayLike, ArrayLike]            # number[n]^3
-    | tuple[ArrayLike, ArrayLike, ArrayLike, ColorSpec] # number[n]^3, colors
-    | axis                                              # axis
-    | tuple[axis, ColorSpec]                            # axis, uint8[n,rgb]
-)
+Series3: TypeAlias = Union[
+    NDArray,                                                      # number[n,3]
+    "tuple[NDArray, ColorSpec]",                                  # number[n,3], colors
+    "tuple[ArrayLike, ArrayLike, ArrayLike]",                     # number[n]^3
+    "tuple[ArrayLike, ArrayLike, ArrayLike, ColorSpec]",          # number[n]^3, colors
+    "axis",                                                       # axis
+    "tuple[axis, ColorSpec]",                                     # axis, uint8[n,rgb]
+]
 
 
 # # # 


### PR DESCRIPTION
## Motivation

`matthewplotlib` currently uses Python 3.12+ `type X = Y` syntax (PEP 695 type aliases) in three files: `colormaps.py`, `colors.py`, and `data.py`. This causes a SyntaxError on Python 3.11 and earlier, making the package unusable in those environments:

```
File ".../matthewplotlib/colormaps.py", line 25
    type ContinuousColorMap = Callable[
         ^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax
```
The project currently declares `requires-python = ">=3.10"` and lists Python 3.10 and 3.11 in its classifiers, so the package should remain importable on those versions. There is no functional reason to require Python 3.12 for aliases that are only used as type annotations.

## Modifications

- Replace `type X = Y` aliases in `colormaps.py`, `colors.py`, and `data.py` with `typing.TypeAlias`, which is available
under the project’s existing Python >=3.10 requirement.
- Union types written as `A | B | C` in the alias bodies are rewritten as `Union[A, B, C]` for the same reason.
- No functional or runtime behavior changes, types are annotations only.

## Checklist

- [ ] No new dependencies beyond `typing_extensions`, which is already a transitive dependency of most scientific Python stacks and is explicitly required by many packages already.